### PR TITLE
Multiple delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ To use `i18n-lint` as a library, install it locally and `require` it in your pro
 var I18nLint = require('i18n-lint');
 
 var errors = I18nLint('some_file.ejs', {
-  templateDelimiters: ['<%','%>'],
+  templateDelimiters: [['<%','%>']],
   attributes: ['title', 'alt', 'data-custom-attr']
 });
 ```
@@ -184,12 +184,12 @@ Options are passed as an object, as the second parameter to `i18n-lint`.
 ##### `templateDelimiters`
 ###### type: `Array`, default: `[]`
 
-Specify the start and end template delimiters which the source files use.  For example,
-when linting EJS files:
+Specify the start and end template delimiters which the source files use.  We can specify
+multiple delimiters if needed. For example, when linting EJS files:
 
 ```javascript
   I18nLint('file.ejs', {
-    templateDelimiters: ['<%', '%>']
+    templateDelimiters: [['<%', '%>']]
   });
 ```
 

--- a/bin/i18n-lint
+++ b/bin/i18n-lint
@@ -45,9 +45,11 @@ program
     '-t, --template-delimiters <delimiters>',
     'Template delimiters used in source files.  For example, Mustache-like ' +
         'templating languages should use \'{{,}}\'',
-    function(raw) {
-      return raw.split(',');
-    }
+    function(raw, accu) {
+      accu.push(raw.split(','));
+      return accu;
+    },
+    []
   )
   .option(
     '-r, --reporter <reporter>',

--- a/lib/i18n-lint.js
+++ b/lib/i18n-lint.js
@@ -209,16 +209,16 @@ I18nLint.scan = function(lines, options) {
   /* @hack @todo replaces all template delimited-content with spaces (see file
    * header)
    */
-  if (options.templateDelimiters.length === 2) {
-    lines = lines.replace(new RegExp(
-      options.templateDelimiters.join('(?:.|\\n|\\r)*?'), 'g'
-    ), function(match) {
+  options.templateDelimiters.forEach(function(delimiters) {
+    if (delimiters.length === 2) {
+      lines = lines.replace(new RegExp(
+        delimiters.join('(?:.|\\n|\\r)*?'), 'g'
+      ), function(match) {
         return match.replace(/./g, ' ');
-    }).split('\n');
-
-  } else {
-    lines = lines.split('\n');
-  }
+      });
+    }
+  });
+  lines = lines.split('\n');
 
   var parser = new htmlparser.Parser({
     /**

--- a/test/bin/i18n-lint.js
+++ b/test/bin/i18n-lint.js
@@ -135,6 +135,23 @@ describe('i18n-lint bin', function() {
     });
   });
 
+  it('-t, --template-delimiters option with multiple delimiters', function(done) {
+    var args = [
+      ' -t "{{,}}" -t "{%,%}" test/fixtures/testing.twig',
+      ' --template-delimiters "{{,}}" --template-delimiters "{%,%}" test/fixtures/testing.twig',
+    ];
+
+    args.forEach(function(arg, i) {
+      exec(cmd + arg, function(err, stdout, stderr) {
+        assert.equal(stdout.match(/Hardcoded <(h1|span|li)> tag/g).length, 3);
+
+        if (i === args.length - 1) {
+          done();
+        }
+      });
+    });
+  });
+
   it('-a, --attributes option should work as expected', function(done) {
     var args = [
       ' -a "title" test/fixtures/multi_instance.html',

--- a/test/fixtures/testing.twig
+++ b/test/fixtures/testing.twig
@@ -1,0 +1,13 @@
+<!-- Page Content -->
+<div class="container">
+
+	<h1>A simple twig example</h1>
+	<div>
+		<ul>
+			{% for word in words %}
+				<li>{{ word }} some text here</li>
+			{% endfor %}
+		</ul>
+        <span>Another untranslated text</span>
+	</div>
+</div>

--- a/test/lib/i18n-lint.js
+++ b/test/lib/i18n-lint.js
@@ -97,14 +97,28 @@ describe('I18nLint lib', function() {
     // Test with EJS-style delimiters, <% and %>
     expect(
       I18nLint('test/fixtures/testing.ejs', {
-        templateDelimiters: ['<%', '%>']
+        templateDelimiters: [['<%', '%>']]
       })
     ).to.have.length(4);
 
     // Test with Mustache-style delimiters, {{ and }}
     expect(
       I18nLint('test/fixtures/testing.hbs', {
-        templateDelimiters: ['{{', '}}']
+        templateDelimiters: [['{{', '}}']]
+      })
+    ).to.have.length(3);
+
+    // Test with multiple delimiters
+    expect(
+      I18nLint('test/fixtures/testing.twig', {
+        templateDelimiters: [['{{', '}}'], ['{%', '%}']]
+      })
+    ).to.have.length(3);
+
+    // Test with a wrong sized delimiter
+    expect(
+      I18nLint('test/fixtures/testing.twig', {
+        templateDelimiters: [['{{'], ['{%', '%}']]
       })
     ).to.have.length(3);
 
@@ -112,7 +126,7 @@ describe('I18nLint lib', function() {
 
   it('should return empty array for clean file', function() {
     var errors = I18nLint('test/fixtures/clean.hbs', {
-      templateDelimiters: ['{{', '}}']
+      templateDelimiters: [['{{', '}}']]
     });
 
     expect(errors).to.be.empty;
@@ -121,7 +135,7 @@ describe('I18nLint lib', function() {
 
   it('should handle text nodes split over multiple lines', function() {
     var errors = I18nLint('test/fixtures/multiline_text_node.hbs', {
-      templateDelimiters: ['{{', '}}']
+      templateDelimiters: [['{{', '}}']]
     });
 
     expect(errors).to.have.length(2);
@@ -140,7 +154,7 @@ describe('I18nLint lib', function() {
 
   it ('should handle a text node with templated content', function() {
     var errors = I18nLint('test/fixtures/text_node_with_template_content.ejs', {
-      templateDelimiters: ['<%', '%>']
+      templateDelimiters: [['<%', '%>']]
     });
 
     expect(errors).to.have.length(1);
@@ -151,7 +165,7 @@ describe('I18nLint lib', function() {
 
   it('should handle attributes with templated content', function() {
     var errors = I18nLint('test/fixtures/attribute_with_template_content.ejs', {
-      templateDelimiters: ['<%', '%>']
+      templateDelimiters: [['<%', '%>']]
     });
 
     expect(errors).to.have.length(1);
@@ -205,7 +219,7 @@ describe('I18nLint lib', function() {
 
   it('should catch hardcoded strings with ... ellipsis', function() {
     var errors = I18nLint('test/fixtures/ellipsis_translation.ejs', {
-      templateDelimiters: ['<%', '%>']
+      templateDelimiters: [['<%', '%>']]
     });
 
     expect(errors).to.have.length(1);


### PR DESCRIPTION
This PR is related to this issue: https://github.com/jwarby/i18n-lint/issues/4

To be able to manage multiple delimiters, we keep the same logic: delimiters come by pairs.
The difference is we store multiple pairs of delimiters in a array, then loop on each on to apply the RegEx.
So, we have some changes to do:
- `['<%', '%>']` became `[['<%', '%>']]`
- `[]` stay as it is